### PR TITLE
Add custom streamdb to packagemapspec & check for unzipped streamdb mods

### DIFF
--- a/EternalModLoader/EternalModLoader.csproj
+++ b/EternalModLoader/EternalModLoader.csproj
@@ -101,6 +101,9 @@
     <Compile Include="Mods\Mod.cs" />
     <Compile Include="Mods\Resources\ResourceName.cs" />
     <Compile Include="Mods\Sounds\SoundEntry.cs" />
+    <Compile Include="Mods\StreamDB\StreamDBContainer.cs" />
+    <Compile Include="Mods\StreamDB\StreamDBEntry.cs" />
+    <Compile Include="Mods\StreamDB\StreamDBModFile.cs" />
     <Compile Include="OnlineSafety.cs" />
     <Compile Include="OodleWrapper.cs" />
     <Compile Include="Mods\Resources\PackageMapSpec.cs" />


### PR DESCRIPTION
Adds the custom .streamdb file (`EternalMod.streamdb`) when needed, also checks for unzipped streamdb mods rather than only for zipped.